### PR TITLE
Support lumen 5.5

### DIFF
--- a/src/Command/GenerateModelCommand.php
+++ b/src/Command/GenerateModelCommand.php
@@ -48,6 +48,15 @@ class GenerateModelCommand extends Command
     }
 
     /**
+     * Executes the command (for lumen 5.5 and above)
+     * From Laravel/Lumen 5.5 fire is no longer used
+     */
+    public function handle()
+    {
+        $this->fire();
+    }
+
+    /**
      * @return Config
      */
     protected function createConfig()


### PR DESCRIPTION
From Laravel/Lumen 5.5, fire() is no longer used.

I got error when running
`php artisan krlove:generate:model Deed --table-name=deeds`

```bash
In BoundMethod.php line 135:

  Method Krlove\EloquentModelGenerator\Command\GenerateModelCommand::handle() does not exist
```